### PR TITLE
Added convinience methods to Sexp and Atom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ keywords = [ "sexp", "parsing", "s-expression", "file-format" ]
 description = "A small, simple, self-contained, s-expression parser and pretty-printer."
 
 license = "MIT"
+
+[dependencies]
+itertools = "0.10.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,3 @@ keywords = [ "sexp", "parsing", "s-expression", "file-format" ]
 description = "A small, simple, self-contained, s-expression parser and pretty-printer."
 
 license = "MIT"
-
-[dependencies]
-itertools = "0.10.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,76 @@ pub enum Atom {
   F(f64),
 }
 
+
+impl Atom {
+  /// Returns true if this atom is a string.
+  pub fn is_string(&self) -> bool {
+    match self {
+      &Atom::S(_) => true,
+      _           => false,
+    }
+  }
+
+  /// Returns true if this atom is an integer.
+  pub fn is_int(&self) -> bool {
+    match self {
+      &Atom::I(_) => true,
+      _           => false,
+    }
+  }
+
+  /// Returns true if this atom is a float.
+  pub fn is_float(&self) -> bool {
+    match self {
+      &Atom::F(_) => true,
+      _           => false,
+    }
+  }
+
+  /// Return the string contained in this atom, panic if it is not a string.
+  pub fn string(&self) -> &str {
+    self.try_string().expect("not a string")
+  }
+
+  /// Try to return the string contained in this atom, or None if it is not a
+  /// string.
+  pub fn try_string(&self) -> Option<&str> {
+    match self {
+      &Atom::S(ref s) => Some(s),
+      _               => None,
+    }
+  }
+
+  /// Return the integer contained in this atom, panic if it is not an integer.
+  pub fn int(&self) -> i64 {
+    self.try_int().expect("not an int")
+  }
+
+  /// Try to return the integer contained in this atom, or None if it is not an
+  /// integer.
+  pub fn try_int(&self) -> Option<i64> {
+    match self {
+      &Atom::I(i) => Some(i),
+      _           => None,
+    }
+  }
+
+  /// Return the float contained in this atom, panic if it is not a float.
+  pub fn float(&self) -> f64 {
+    self.try_float().expect("not a float")
+  }
+
+  /// Try to return the float contained in this atom, or None if it is not a
+  /// float.
+  pub fn try_float(&self) -> Option<f64> {
+    match self {
+      &Atom::F(f) => Some(f),
+      _           => None,
+    }
+  }
+}
+
+
 /// An s-expression is either an atom or a list of s-expressions. This is
 /// similar to the data format used by lisp.
 #[derive(PartialEq, Clone, PartialOrd)]
@@ -30,6 +100,51 @@ pub enum Atom {
 pub enum Sexp {
   Atom(Atom),
   List(Vec<Sexp>),
+}
+
+impl Sexp {
+  /// Returns true if this s-expression is an atom.
+  pub fn is_atom(&self) -> bool {
+    match self {
+      Sexp::Atom(_) => true,
+      _             => false,
+    }
+  }
+
+  /// Returns true if this s-expression is a list.
+  pub fn is_list(&self) -> bool {
+    match *self {
+      Sexp::List(_) => true,
+      _             => false,
+    }
+  }
+
+  /// Return the atom contained in this s-expression, panic if it is a list.
+  pub fn atom(&self) -> &Atom {
+    self.try_atom().expect("not an atom")
+  }
+
+  /// Try to return the atom contained in this s-expression, or None if it is a
+  pub fn try_atom(&self) -> Option<&Atom> {
+    match self {
+      &Sexp::Atom(ref a) => Some(a),
+      _                  => None,
+    }
+  }
+
+  /// Return the list contained in this s-expression, panic if it is an atom.
+  pub fn list(&self) -> &Vec<Sexp> {
+    self.try_list().expect("not a list")
+  }
+
+  /// Try to return the list contained in this s-expression, or None if it is an
+  /// atom.
+  pub fn try_list(&self) -> Option<&Vec<Sexp>> {
+    match self {
+      &Sexp::List(ref l) => Some(l),
+      _                  => None,
+    }
+  }
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,6 @@ use std::error;
 use std::fmt;
 use std::str::{self, FromStr};
 
-extern crate itertools;
-use itertools::Itertools;
-
 /// A single data element in an s-expression. Floats are excluded to ensure
 /// atoms may be used as keys in ordered and hashed data structures.
 ///
@@ -195,11 +192,12 @@ impl Sexp {
   pub fn into_map(self) -> Option<BTreeMap<String, Sexp>> {
     match self {
       Sexp::List(l) => {
-        if l.len() % 2 != 0 {
-          return None;
-        }
         let mut map = BTreeMap::new();
-        for (key, value) in l.into_iter().tuple_windows::<(Sexp, Sexp)>() {
+        for sub_l in l.into_iter() {
+          assert!(sub_l.is_list() && sub_l.list().len() == 2);
+          let mut sub_l = sub_l.into_list().unwrap();
+          let value = sub_l.remove(1);
+          let key = sub_l.remove(0);
           let key = key.into_atom()?.into_string()?;
           assert!(!map.contains_key(&key));
           map.insert(key, value);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ impl Sexp {
 
   /// Return the atom contained in this s-expression, panic if it is a list.
   pub fn atom(&self) -> &Atom {
-    self.try_atom().expect("not an atom")
+    self.try_atom().expect(&format!("Expecting an atom, got: {}", self))
   }
 
   /// Try to return the atom contained in this s-expression, or None if it is a
@@ -134,7 +134,7 @@ impl Sexp {
 
   /// Return the list contained in this s-expression, panic if it is an atom.
   pub fn list(&self) -> &Vec<Sexp> {
-    self.try_list().expect("not a list")
+    self.try_list().expect(&format!("Expecting a list, got: {}", self))
   }
 
   /// Try to return the list contained in this s-expression, or None if it is an


### PR DESCRIPTION
This pull request adds concise type-checking and value extraction methods to the existing sexp parsing library. These additions are particularly useful when expecting a specific format of an s-expression. The changes include:

    In the Atom struct:
        Added methods for checking if the atom is a string, integer, or float.
        Added methods for extracting the string, integer, or float value from the atom.

    In the Sexp enum:
        Added methods for checking if the s-expression is an atom or a list.
        Added methods for extracting the atom or list from the s-expression.

These new methods provide a convenient way to validate and extract values from atoms within s-expressions, allowing for easier handling of expected formats. This enhances the usability and flexibility of the library when working with specific types of atoms within s-expressions.